### PR TITLE
close the window on escape key press

### DIFF
--- a/cbpp-exit/data/usr/bin/cbpp-exit
+++ b/cbpp-exit/data/usr/bin/cbpp-exit
@@ -3,7 +3,7 @@
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 
 import getpass
 import os
@@ -25,6 +25,8 @@ class ButtonWindow(Gtk.Window):
 		
 		hbox = Gtk.Box(spacing=6)
 		vbox.pack_start(hbox, True, True, 0)
+
+		self.connect("key_press_event", self.on_esc_pressed)
 
 		self.cbutton = Gtk.Button.new_with_mnemonic("_Cancel")
 		self.cbutton.set_border_width(4)
@@ -62,7 +64,11 @@ class ButtonWindow(Gtk.Window):
 		self.rbutton.set_sensitive(False)
 		self.pbutton.set_sensitive(False)
 
-	def on_cancel_clicked(self, button):
+	def on_esc_pressed(self, win, event_key):
+		if event_key.keyval == Gdk.KEY_Escape:
+			self.on_cancel_clicked()
+
+	def on_cancel_clicked(self, button=None):
 		self.disable_buttons()
 		Gtk.main_quit()
 


### PR DESCRIPTION
Hello for a long time now, I have been thinking that the exit window could close on escape key press.
It can be safer, in a way.
I am not a Gtk expert but I feel it is a good way to achieve that goal since inheriting from Dialog instead of Window is not possible in this case.

I preferred making the second argument of on_cancel_clicked optional than passing None to the call done by on_cancel_clicked to avoid unseen side effects if the argument become mandatory.

I hope I followed the PR process right (with the proper branch!).

Thanks.